### PR TITLE
add google-pilot logID

### DIFF
--- a/app/js/services.js
+++ b/app/js/services.js
@@ -9,6 +9,7 @@ angular.module('myApp.services', [])
                         id: "google-pilot",
                         name: "Google Pilot",
                         urlPrefix: "ct.googleapis.com/pilot",
+                        logId: "pLkJkLQYWBSHuxOizGdwCjw1mAT5G9+443fNDsgN3BA=",
                         announceUrl: "https://www.imperialviolet.org/2013/08/01/ctpilot.html",
                         good: true
                     },


### PR DESCRIPTION
adding Google CT pilot log ID, as found on: http://www.certificate-transparency.org/known-logs. confirmed through the Chrome UI looking at a cert issued with an SCT from that log included. (this is the only log missing the logID)